### PR TITLE
Add index-management standby mode guards

### DIFF
--- a/src/main/kotlin/org/opensearch/indexmanagement/IndexManagementPlugin.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/IndexManagementPlugin.kt
@@ -147,6 +147,7 @@ import org.opensearch.indexmanagement.spi.indexstatemanagement.IndexMetadataServ
 import org.opensearch.indexmanagement.spi.indexstatemanagement.StatusChecker
 import org.opensearch.indexmanagement.spi.indexstatemanagement.metrics.IndexManagementActionsMetrics
 import org.opensearch.indexmanagement.spi.indexstatemanagement.model.ManagedIndexMetaData
+import org.opensearch.indexmanagement.standby.StandbyModeActionFilter
 import org.opensearch.indexmanagement.transform.TargetIndexMappingService
 import org.opensearch.indexmanagement.transform.TransformRunner
 import org.opensearch.indexmanagement.transform.action.delete.DeleteTransformsAction
@@ -198,6 +199,7 @@ import org.opensearch.transport.TransportInterceptor
 import org.opensearch.transport.TransportService
 import org.opensearch.transport.client.Client
 import org.opensearch.watcher.ResourceWatcherService
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.function.Supplier
 
 @Suppress("TooManyFunctions")
@@ -222,6 +224,8 @@ class IndexManagementPlugin :
     private val extensions = mutableSetOf<String>()
     private val extensionCheckerMap = mutableMapOf<String, StatusChecker>()
     lateinit var indexOperationActionFilter: IndexOperationActionFilter
+    lateinit var standbyModeActionFilter: StandbyModeActionFilter
+    private val standbyModeEnabled = AtomicBoolean(false)
     private lateinit var metricsRegistry: MetricsRegistry
 
     companion object {
@@ -398,6 +402,9 @@ class IndexManagementPlugin :
         val settings = environment.settings()
         this.metricsRegistry = metricsRegistry
         this.clusterService = clusterService
+        standbyModeEnabled.set(IndexManagementSettings.CLUSTER_STANDBY_MODE.get(settings))
+        clusterService.clusterSettings.addSettingsUpdateConsumer(IndexManagementSettings.CLUSTER_STANDBY_MODE, standbyModeEnabled::set)
+        IndexManagementRunner.registerStandbyModeSupplier(standbyModeEnabled::get)
         QueryShardContextFactory.init(
             client,
             clusterService,
@@ -494,6 +501,7 @@ class IndexManagementPlugin :
                 ActiveShardsObserver(clusterService, client.threadPool()),
                 indexNameExpressionResolver,
             )
+        standbyModeActionFilter = StandbyModeActionFilter(standbyModeEnabled::get)
 
         TargetIndexMappingService.initialize(client)
 
@@ -552,6 +560,7 @@ class IndexManagementPlugin :
         TransformSettings.TRANSFORM_JOB_SEARCH_BACKOFF_MILLIS,
         TransformSettings.TRANSFORM_CIRCUIT_BREAKER_ENABLED,
         TransformSettings.TRANSFORM_CIRCUIT_BREAKER_JVM_THRESHOLD,
+        IndexManagementSettings.CLUSTER_STANDBY_MODE,
         IndexManagementSettings.FILTER_BY_BACKEND_ROLES,
         LegacyOpenDistroManagedIndexSettings.HISTORY_ENABLED,
         LegacyOpenDistroManagedIndexSettings.HISTORY_INDEX_MAX_AGE,
@@ -628,7 +637,7 @@ class IndexManagementPlugin :
         threadContext: ThreadContext,
     ): List<TransportInterceptor> = listOf(rollupInterceptor)
 
-    override fun getActionFilters(): List<ActionFilter> = listOf(fieldCapsFilter, indexOperationActionFilter)
+    override fun getActionFilters(): List<ActionFilter> = listOf(standbyModeActionFilter, fieldCapsFilter, indexOperationActionFilter)
 
     override fun getSystemIndexDescriptors(settings: Settings): Collection<SystemIndexDescriptor> = listOf(
         SystemIndexDescriptor(

--- a/src/main/kotlin/org/opensearch/indexmanagement/IndexManagementRunner.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/IndexManagementRunner.kt
@@ -17,11 +17,23 @@ import org.opensearch.indexmanagement.transform.model.Transform
 import org.opensearch.jobscheduler.spi.JobExecutionContext
 import org.opensearch.jobscheduler.spi.ScheduledJobParameter
 import org.opensearch.jobscheduler.spi.ScheduledJobRunner
+import java.util.function.Supplier
 
 object IndexManagementRunner : ScheduledJobRunner {
     private val logger = LogManager.getLogger(javaClass)
+    private var standbyModeEnabled: Supplier<Boolean> = Supplier { false }
+
+    fun registerStandbyModeSupplier(standbyModeEnabled: Supplier<Boolean>): IndexManagementRunner {
+        this.standbyModeEnabled = standbyModeEnabled
+        return this
+    }
 
     override fun runJob(job: ScheduledJobParameter, context: JobExecutionContext) {
+        if (standbyModeEnabled.get()) {
+            logger.debug("Index Management standby mode is enabled, skipping scheduled job [{}].", context.jobId)
+            return
+        }
+
         when (job) {
             is ManagedIndexConfig -> ManagedIndexRunner.runJob(job, context)
 

--- a/src/main/kotlin/org/opensearch/indexmanagement/settings/IndexManagementSettings.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/settings/IndexManagementSettings.kt
@@ -9,6 +9,14 @@ import org.opensearch.common.settings.Setting
 @Suppress("UtilityClassWithPublicConstructor")
 class IndexManagementSettings {
     companion object {
+        val CLUSTER_STANDBY_MODE: Setting<Boolean> =
+            Setting.boolSetting(
+                "cluster.standby_mode",
+                false,
+                Setting.Property.NodeScope,
+                Setting.Property.Dynamic,
+            )
+
         val FILTER_BY_BACKEND_ROLES: Setting<Boolean> =
             Setting.boolSetting(
                 "plugins.index_management.filter_by_backend_roles",

--- a/src/main/kotlin/org/opensearch/indexmanagement/standby/StandbyModeActionFilter.kt
+++ b/src/main/kotlin/org/opensearch/indexmanagement/standby/StandbyModeActionFilter.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.indexmanagement.standby
+
+import org.apache.logging.log4j.LogManager
+import org.opensearch.OpenSearchStatusException
+import org.opensearch.action.ActionRequest
+import org.opensearch.action.support.ActionFilter
+import org.opensearch.action.support.ActionFilterChain
+import org.opensearch.action.support.ActionRequestMetadata
+import org.opensearch.core.action.ActionListener
+import org.opensearch.core.action.ActionResponse
+import org.opensearch.core.rest.RestStatus
+import org.opensearch.indexmanagement.controlcenter.notification.action.delete.DeleteLRONConfigAction
+import org.opensearch.indexmanagement.controlcenter.notification.action.index.IndexLRONConfigAction
+import org.opensearch.indexmanagement.indexstatemanagement.transport.action.addpolicy.AddPolicyAction
+import org.opensearch.indexmanagement.indexstatemanagement.transport.action.changepolicy.ChangePolicyAction
+import org.opensearch.indexmanagement.indexstatemanagement.transport.action.deletepolicy.DeletePolicyAction
+import org.opensearch.indexmanagement.indexstatemanagement.transport.action.indexpolicy.IndexPolicyAction
+import org.opensearch.indexmanagement.indexstatemanagement.transport.action.managedIndex.ManagedIndexAction
+import org.opensearch.indexmanagement.indexstatemanagement.transport.action.removepolicy.RemovePolicyAction
+import org.opensearch.indexmanagement.indexstatemanagement.transport.action.retryfailedmanagedindex.RetryFailedManagedIndexAction
+import org.opensearch.indexmanagement.rollup.action.delete.DeleteRollupAction
+import org.opensearch.indexmanagement.rollup.action.index.IndexRollupAction
+import org.opensearch.indexmanagement.rollup.action.start.StartRollupAction
+import org.opensearch.indexmanagement.rollup.action.stop.StopRollupAction
+import org.opensearch.indexmanagement.snapshotmanagement.api.transport.SMActions
+import org.opensearch.indexmanagement.transform.action.delete.DeleteTransformsAction
+import org.opensearch.indexmanagement.transform.action.index.IndexTransformAction
+import org.opensearch.indexmanagement.transform.action.start.StartTransformAction
+import org.opensearch.indexmanagement.transform.action.stop.StopTransformAction
+import org.opensearch.tasks.Task
+import java.util.function.Supplier
+
+class StandbyModeActionFilter(
+    private val standbyModeEnabled: Supplier<Boolean>,
+) : ActionFilter {
+    private val logger = LogManager.getLogger(javaClass)
+
+    override fun order() = Integer.MIN_VALUE
+
+    override fun <Request : ActionRequest, Response : ActionResponse> apply(
+        task: Task,
+        action: String,
+        request: Request,
+        actionRequestMetadata: ActionRequestMetadata<Request, Response>,
+        listener: ActionListener<Response>,
+        chain: ActionFilterChain<Request, Response>,
+    ) {
+        if (standbyModeEnabled.get() && MUTATING_ACTIONS.contains(action)) {
+            logger.debug("Index Management standby mode is enabled, rejecting mutating action [{}].", action)
+            listener.onFailure(
+                OpenSearchStatusException(
+                    "Index Management is read-only because this cluster is in standby mode.",
+                    RestStatus.FORBIDDEN,
+                ),
+            )
+            return
+        }
+
+        chain.proceed(task, action, request, listener)
+    }
+
+    companion object {
+        val MUTATING_ACTIONS = setOf(
+            AddPolicyAction.NAME,
+            ChangePolicyAction.NAME,
+            DeletePolicyAction.NAME,
+            IndexPolicyAction.NAME,
+            ManagedIndexAction.NAME,
+            RemovePolicyAction.NAME,
+            RetryFailedManagedIndexAction.NAME,
+            DeleteRollupAction.NAME,
+            IndexRollupAction.NAME,
+            StartRollupAction.NAME,
+            StopRollupAction.NAME,
+            SMActions.DELETE_SM_POLICY_ACTION_NAME,
+            SMActions.INDEX_SM_POLICY_ACTION_NAME,
+            SMActions.START_SM_POLICY_ACTION_NAME,
+            SMActions.STOP_SM_POLICY_ACTION_NAME,
+            DeleteTransformsAction.NAME,
+            IndexTransformAction.NAME,
+            StartTransformAction.NAME,
+            StopTransformAction.NAME,
+            DeleteLRONConfigAction.NAME,
+            IndexLRONConfigAction.NAME,
+        )
+    }
+}

--- a/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementRunnerTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/IndexManagementRunnerTests.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.indexmanagement
+
+import org.mockito.Mockito
+import org.opensearch.jobscheduler.spi.JobExecutionContext
+import org.opensearch.jobscheduler.spi.ScheduledJobParameter
+import org.opensearch.test.OpenSearchTestCase
+import java.util.concurrent.atomic.AtomicBoolean
+
+class IndexManagementRunnerTests : OpenSearchTestCase() {
+    fun `test run job returns early in standby mode`() {
+        val standbyModeEnabled = AtomicBoolean(true)
+        IndexManagementRunner.registerStandbyModeSupplier(standbyModeEnabled::get)
+
+        val job = Mockito.mock(ScheduledJobParameter::class.java)
+        val context = Mockito.mock(JobExecutionContext::class.java)
+        Mockito.`when`(context.jobId).thenReturn("standby-job")
+
+        IndexManagementRunner.runJob(job, context)
+    }
+
+    override fun tearDown() {
+        IndexManagementRunner.registerStandbyModeSupplier { false }
+        super.tearDown()
+    }
+}

--- a/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/IndexStateManagementRestApiIT.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/IndexStateManagementRestApiIT.kt
@@ -23,6 +23,7 @@ import org.opensearch.indexmanagement.indexstatemanagement.randomReadOnlyActionC
 import org.opensearch.indexmanagement.indexstatemanagement.randomState
 import org.opensearch.indexmanagement.indexstatemanagement.settings.ManagedIndexSettings
 import org.opensearch.indexmanagement.makeRequest
+import org.opensearch.indexmanagement.settings.IndexManagementSettings
 import org.opensearch.indexmanagement.util.NO_ID
 import org.opensearch.indexmanagement.util._ID
 import org.opensearch.indexmanagement.util._PRIMARY_TERM
@@ -77,6 +78,34 @@ class IndexStateManagementRestApiIT : IndexStateManagementRestTestCase() {
         assertEquals("incorrect primaryTerm", 1, createdPrimaryTerm)
 
         assertEquals("Incorrect Location header", "$POLICY_BASE_URI/$createdId", createResponse.getHeader("Location"))
+    }
+
+    fun `test standby mode rejects policy writes`() {
+        try {
+            updateClusterSetting(IndexManagementSettings.CLUSTER_STANDBY_MODE.key, "true", false)
+
+            val standbyException = expectThrows(ResponseException::class.java) {
+                client().makeRequest(
+                    "PUT",
+                    "$POLICY_BASE_URI/${OpenSearchTestCase.randomAlphaOfLength(10)}",
+                    emptyMap(),
+                    randomPolicy().toHttpEntity(),
+                )
+            }
+            assertEquals(RestStatus.FORBIDDEN, standbyException.response.restStatus())
+
+            updateClusterSetting(IndexManagementSettings.CLUSTER_STANDBY_MODE.key, "false", false)
+            val createResponse =
+                client().makeRequest(
+                    "PUT",
+                    "$POLICY_BASE_URI/${OpenSearchTestCase.randomAlphaOfLength(10)}",
+                    emptyMap(),
+                    randomPolicy().toHttpEntity(),
+                )
+            assertEquals(RestStatus.CREATED, createResponse.restStatus())
+        } finally {
+            updateClusterSetting(IndexManagementSettings.CLUSTER_STANDBY_MODE.key, "false", false)
+        }
     }
 
     @Throws(Exception::class)

--- a/src/test/kotlin/org/opensearch/indexmanagement/standby/StandbyModeActionFilterTests.kt
+++ b/src/test/kotlin/org/opensearch/indexmanagement/standby/StandbyModeActionFilterTests.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.indexmanagement.standby
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.mockito.Mockito
+import org.opensearch.OpenSearchStatusException
+import org.opensearch.action.ActionRequest
+import org.opensearch.action.admin.cluster.node.info.NodesInfoAction
+import org.opensearch.action.support.ActionFilterChain
+import org.opensearch.action.support.ActionRequestMetadata
+import org.opensearch.core.action.ActionListener
+import org.opensearch.core.action.ActionResponse
+import org.opensearch.core.rest.RestStatus
+import org.opensearch.indexmanagement.indexstatemanagement.transport.action.indexpolicy.IndexPolicyAction
+import org.opensearch.tasks.Task
+import org.opensearch.test.OpenSearchTestCase
+
+class StandbyModeActionFilterTests : OpenSearchTestCase() {
+    fun `test rejects mutating action in standby mode`() {
+        val filter = StandbyModeActionFilter { true }
+        val listener = CapturingActionListener<ActionResponse>()
+
+        filter.apply(
+            Mockito.mock(Task::class.java),
+            IndexPolicyAction.NAME,
+            Mockito.mock(ActionRequest::class.java),
+            actionRequestMetadata(),
+            listener,
+            actionFilterChain(),
+        )
+
+        val failure = listener.failure as OpenSearchStatusException
+        assertEquals(RestStatus.FORBIDDEN, failure.status())
+    }
+
+    fun `test proceeds for read action in standby mode`() {
+        val filter = StandbyModeActionFilter { true }
+        val listener = CapturingActionListener<ActionResponse>()
+        val chain = CapturingActionFilterChain()
+        val request = Mockito.mock(ActionRequest::class.java)
+
+        filter.apply(
+            Mockito.mock(Task::class.java),
+            NodesInfoAction.NAME,
+            request,
+            actionRequestMetadata(),
+            listener,
+            chain,
+        )
+
+        assertNull(listener.failure)
+        assertSame(request, chain.request)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun actionRequestMetadata(): ActionRequestMetadata<ActionRequest, ActionResponse> =
+        Mockito.mock(ActionRequestMetadata::class.java) as ActionRequestMetadata<ActionRequest, ActionResponse>
+
+    @Suppress("UNCHECKED_CAST")
+    private fun actionFilterChain(): ActionFilterChain<ActionRequest, ActionResponse> =
+        Mockito.mock(ActionFilterChain::class.java) as ActionFilterChain<ActionRequest, ActionResponse>
+
+    private class CapturingActionListener<Response : ActionResponse> : ActionListener<Response> {
+        var failure: Exception? = null
+
+        override fun onResponse(response: Response) {}
+
+        override fun onFailure(e: Exception) {
+            failure = e
+        }
+    }
+
+    private class CapturingActionFilterChain : ActionFilterChain<ActionRequest, ActionResponse> {
+        var request: ActionRequest? = null
+
+        override fun proceed(
+            task: Task,
+            action: String,
+            request: ActionRequest,
+            listener: ActionListener<ActionResponse>,
+        ) {
+            this.request = request
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds standby-mode handling to Index Management so a follower cluster can remain read-only for plugin-owned configuration while replicated state is expected to come from the active leader.

## Changes

- Adds a temporary plugin-local dynamic `cluster.standby_mode` setting.
- Wires the setting into `IndexManagementPlugin` and keeps an in-memory standby flag updated through cluster settings.
- Skips scheduled Index Management execution while standby mode is enabled, covering:
  - ISM managed index jobs
  - Rollup jobs
  - Transform jobs
  - Snapshot management jobs
- Adds a central `StandbyModeActionFilter` that rejects mutating Index Management transport actions with `403 FORBIDDEN` while standby mode is enabled.
- Leaves read-style APIs such as get/search/explain/preview available.
- Adds focused unit tests and a REST integration test for standby policy-write rejection and recovery after disabling standby mode.

## Why

In a disaster-recovery setup, Index Management configuration such as `.opendistro-ism-config` can be replicated from an active leader cluster to a standby follower. The follower should not also accept local policy/job/config mutations, because those writes can diverge from the replicated source of truth.

Job Scheduler standby behavior prevents scheduled jobs from firing, but Index Management still exposes explicit mutation APIs. This PR adds plugin-level guards for those APIs and skips scheduled execution as a second layer of protection.

## Notes

The local `cluster.standby_mode` setting is intended to be replaced with the core OpenSearch setting constant once this plugin builds against the core standby-mode change.

## Validation

```bash
./gradlew test --tests 'org.opensearch.indexmanagement.IndexManagementRunnerTests' --tests 'org.opensearch.indexmanagement.standby.StandbyModeActionFilterTests'
./gradlew integTest --tests 'org.opensearch.indexmanagement.indexstatemanagement.resthandler.IndexStateManagementRestApiIT.test standby mode rejects policy writes'
```
